### PR TITLE
Make principals general

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ and gives permission to the entities specified in `principals_arns` to assume th
     principals = {
       AWS = ["arn:aws:iam::123456789012:role/workers"]
     }
-    
+
     policy_documents = [
       "${data.aws_iam_policy_document.resource_full_access.json}",
       "${data.aws_iam_policy_document.base.json}",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ and gives permission to the entities specified in `principals_arns` to assume th
     policy_description = "Allow S3 FullAccess"
     role_description   = "IAM role with permissions to perform actions on S3 resources"
 
-    principals_arns = ["arn:aws:iam::123456789012:role/workers"]
+    principals = {
+      AWS = ["arn:aws:iam::123456789012:role/workers"]
+    }
+    
     policy_documents = [
       "${data.aws_iam_policy_document.resource_full_access.json}",
       "${data.aws_iam_policy_document.base.json}",
@@ -130,11 +133,11 @@ The [`example`](./example) directory contains complete working examples with var
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | policy_description | The description of the IAM policy that is visible in the IAM policy manager | string | - | yes |
 | policy_documents | List of JSON IAM policy documents | list | `<list>` | no |
-| principals_arns | List of ARNs to allow assuming the role. Could be AWS accounts, Kops nodes, IAM users or groups | list | - | yes |
-| principals_services_arns | List of Services identifiers to allow assuming the role. | list | `<list>` | no |
+| principals | Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | map | `<map>` | no |
 | role_description | The description of the IAM role that is visible in the IAM role manager | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| use_fullname | Set 'true' to use `namespace-stage-name` for ecr repository name, else `name` | string | `true` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -100,7 +100,7 @@ usage: |-
       principals = {
         AWS = ["arn:aws:iam::123456789012:role/workers"]
       }
-      
+
       policy_documents = [
         "${data.aws_iam_policy_document.resource_full_access.json}",
         "${data.aws_iam_policy_document.base.json}",

--- a/README.yaml
+++ b/README.yaml
@@ -97,7 +97,10 @@ usage: |-
       policy_description = "Allow S3 FullAccess"
       role_description   = "IAM role with permissions to perform actions on S3 resources"
 
-      principals_arns = ["arn:aws:iam::123456789012:role/workers"]
+      principals = {
+        AWS = ["arn:aws:iam::123456789012:role/workers"]
+      }
+      
       policy_documents = [
         "${data.aws_iam_policy_document.resource_full_access.json}",
         "${data.aws_iam_policy_document.base.json}",

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,11 +10,11 @@
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | policy_description | The description of the IAM policy that is visible in the IAM policy manager | string | - | yes |
 | policy_documents | List of JSON IAM policy documents | list | `<list>` | no |
-| principals_arns | List of ARNs to allow assuming the role. Could be AWS accounts, Kops nodes, IAM users or groups | list | - | yes |
-| principals_services_arns | List of Services identifiers to allow assuming the role. | list | `<list>` | no |
+| principals | Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | map | `<map>` | no |
 | role_description | The description of the IAM role that is visible in the IAM role manager | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| use_fullname | Set 'true' to use `namespace-stage-name` for ecr repository name, else `name` | string | `true` | no |
 
 ## Outputs
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -74,7 +74,7 @@ module "role" {
   stage     = "prod"
   name      = "app"
 
-  principals_arns = []
+  principals = {}
 
   policy_documents = [
     "${data.aws_iam_policy_document.resource_full_access.json}",

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "principals" {
   count = "${length(var.principals)}"
   triggers {
     type = "${element(local.services, count.index)}"
-    identifiers = ["${lookup(var.principals, element(local.services, count.index))}"]
+    identifiers = ["${var.principals[element(local.services, count.index)]}"]
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -11,14 +11,13 @@ module "label" {
 
 locals {
   services = ["${keys(var.principals)}"]
-  values = ["${values(var.principals)}"]
 }
 
 resource "null_resource" "principals" {
   count = "${length(var.principals)}"
   triggers {
     type = "${element(local.services, count.index)}"
-    identifiers = ["${element(local.values, count.index)}"]
+    identifiers = ["${lookup(var.principals, element(local.services, count.index))}"]
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "assume_role" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type        = "${element(keys(var.principals), count.index)}"
+      type = "${element(keys(var.principals), count.index)}"
       identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
     }
   }
@@ -26,6 +26,14 @@ data "aws_iam_policy_document" "assume_role" {
 module "aggregated_assume_policy" {
   source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = ["${data.aws_iam_policy_document.assume_role.*.json}"]
+}
+
+resource "aws_iam_role" "default" {
+  count                = "${var.enabled == "true" ? 1 : 0}"
+  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
+  assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
+  description          = "${var.role_description}"
+  max_session_duration = "${var.max_session_duration}"
 }
 
 module "aggregated_policy" {
@@ -38,14 +46,6 @@ resource "aws_iam_policy" "default" {
   name        = "${module.label.id}"
   description = "${var.policy_description}"
   policy      = "${module.aggregated_policy.result_document}"
-}
-
-resource "aws_iam_role" "default" {
-  count                = "${var.enabled == "true" ? 1 : 0}"
-  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
-  assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
-  description          = "${var.role_description}"
-  max_session_duration = "${var.max_session_duration}"
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "principals" {
   count = "${length(keys(var.principals))}"
   triggers {
     type = "${element(keys(var.principals), count.index)}"
-    identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
+    #identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  count      = "${var.enabled == "true" && length(var.policy_documents) > 0- ? 1 : 0}"
+  count      = "${var.enabled == "true" && length(var.policy_documents) > 0 ? 1 : 0}"
   role       = "${aws_iam_role.default.name}"
   policy_arn = "${aws_iam_policy.default.arn}"
 }

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "principals" {
   count = "${length(keys(var.principals))}"
   triggers {
     type = "${element(keys(var.principals), count.index)}"
-    identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
+    # identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -9,15 +9,11 @@ module "label" {
   enabled    = "${var.enabled}"
 }
 
-locals {
-  services = ["${keys(var.principals)}"]
-}
-
 resource "null_resource" "principals" {
-  count = "${length(local.services)}"
+  count = "${length(keys(var.principals))}"
   triggers {
-    type = "${element(local.services, count.index)}"
-    identifiers = ["${var.principals[element(local.services, count.index)]}"]
+    type = "${element(keys(var.principals), count.index)}"
+    identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "null_resource" "principals" {
-  count = "${length(var.principals)}"
+  count = "${length(local.services)}"
   triggers {
     type = "${element(local.services, count.index)}"
     identifiers = ["${var.principals[element(local.services, count.index)]}"]

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,14 @@ module "aggregated_assume_policy" {
   source_documents = ["${data.aws_iam_policy_document.assume_role.*.json}"]
 }
 
+resource "aws_iam_role" "default" {
+  count                = "${var.enabled == "true" ? 1 : 0}"
+  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
+  assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
+  description          = "${var.role_description}"
+  max_session_duration = "${var.max_session_duration}"
+}
+
 module "aggregated_policy" {
   source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = ["${var.policy_documents}"]
@@ -38,14 +46,6 @@ resource "aws_iam_policy" "default" {
   name        = "${module.label.id}"
   description = "${var.policy_description}"
   policy      = "${module.aggregated_policy.result_document}"
-}
-
-resource "aws_iam_role" "default" {
-  count                = "${var.enabled == "true" ? 1 : 0}"
-  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
-  assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
-  description          = "${var.role_description}"
-  max_session_duration = "${var.max_session_duration}"
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "principals" {
   count = "${length(keys(var.principals))}"
   triggers {
     type = "${element(keys(var.principals), count.index)}"
-    # identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
+    identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
   }
 
   lifecycle {
@@ -26,7 +26,8 @@ data "aws_iam_policy_document" "assume_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = ["${merge(null_resource.principals.*.triggers, map())}"]
+    #principals = ["${merge(null_resource.principals.*.triggers, map())}"]
+    principals = [{type = "Service", identifiers = ["cloudformation.amazonaws.com"]}]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ module "aggregated_policy" {
 }
 
 resource "aws_iam_policy" "default" {
-  count       = "${var.enabled == "true" ? 1 : 0}"
+  count       = "${var.enabled == "true" && length(var.policy_documents) > 0 ? 1 : 0}"
   name        = "${module.label.id}"
   description = "${var.policy_description}"
   policy      = "${module.aggregated_policy.result_document}"
@@ -56,7 +56,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  count      = "${var.enabled == "true" ? 1 : 0}"
+  count      = "${var.enabled == "true" && length(var.policy_documents) > 0- ? 1 : 0}"
   role       = "${aws_iam_role.default.name}"
   policy_arn = "${aws_iam_policy.default.arn}"
 }

--- a/main.tf
+++ b/main.tf
@@ -17,20 +17,19 @@ data "aws_iam_policy_document" "assume_role" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "${element(keys(var.principals), count.index)}"
+      type        = "${element(keys(var.principals), count.index)}"
       identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
     }
   }
 }
 
 module "aggregated_assume_policy" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=fix-empty-policy"
+  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = ["${data.aws_iam_policy_document.assume_role.*.json}"]
 }
 
-
 module "aggregated_policy" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=fix-empty-policy"
+  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = ["${var.policy_documents}"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,11 @@ data "aws_iam_policy_document" "assume_role" {
     actions = ["sts:AssumeRole"]
 
     #principals = ["${merge(null_resource.principals.*.triggers, map())}"]
-    principals = [{type = "Service", identifiers = ["cloudformation.amazonaws.com"]}]
+    principals {
+      type = "Service"
+      identifiers = ["cloudformation.amazonaws.com"]
+    }
+    # [{type = "Service", identifiers = ["cloudformation.amazonaws.com"]}]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 module "aggregated_policy" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.1"
+  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=fix-empty-policy"
   source_documents = ["${var.policy_documents}"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,14 +28,6 @@ module "aggregated_assume_policy" {
   source_documents = ["${data.aws_iam_policy_document.assume_role.*.json}"]
 }
 
-resource "aws_iam_role" "default" {
-  count                = "${var.enabled == "true" ? 1 : 0}"
-  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
-  assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
-  description          = "${var.role_description}"
-  max_session_duration = "${var.max_session_duration}"
-}
-
 module "aggregated_policy" {
   source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = ["${var.policy_documents}"]
@@ -46,6 +38,14 @@ resource "aws_iam_policy" "default" {
   name        = "${module.label.id}"
   description = "${var.policy_description}"
   policy      = "${module.aggregated_policy.result_document}"
+}
+
+resource "aws_iam_role" "default" {
+  count                = "${var.enabled == "true" ? 1 : 0}"
+  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
+  assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
+  description          = "${var.role_description}"
+  max_session_duration = "${var.max_session_duration}"
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "assume_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = ["${null_resource.principals.*.triggers}"]
+    principals = ["${merge(null_resource.principals.*.triggers, map())}"]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "aws_iam_policy" "default" {
 
 resource "aws_iam_role" "default" {
   count                = "${var.enabled == "true" ? 1 : 0}"
-  name                 = "${module.label.id}"
+  name                 = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
   assume_role_policy   = "${module.aggregated_assume_policy.result_document}"
   description          = "${var.role_description}"
   max_session_duration = "${var.max_session_duration}"

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,8 @@ variable "tags" {
 
 variable "principals" {
   type        = "map"
-  description = "List of ARNs to allow assuming the role. Could be AWS accounts, Kops nodes, IAM users or groups"
+  description = "Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`)))"
+  default     = {}
 }
 
 variable "policy_documents" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,14 +31,8 @@ variable "tags" {
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
-variable "principals_services_arns" {
-  type        = "list"
-  default     = ["ec2.amazonaws.com"]
-  description = "List of Services identifiers to allow assuming the role."
-}
-
-variable "principals_arns" {
-  type        = "list"
+variable "principals" {
+  type        = "map"
   description = "List of ARNs to allow assuming the role. Could be AWS accounts, Kops nodes, IAM users or groups"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "name" {
   description = "Name (e.g. `app` or `chamber`)"
 }
 
+variable "use_fullname" {
+  type        = "string"
+  default     = "true"
+  description = "Set 'true' to use `namespace-stage-name` for ecr repository name, else `name`"
+}
+
 variable "delimiter" {
   type        = "string"
   default     = "-"


### PR DESCRIPTION
## What
* Added support for [principals of any type](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html)
* Allow creating a role with a specific name

## Why
* Allow creating roles that can be assumed not only by IAM roles but also by services
* Some services critical to role name, so we can not use name generated by `null-label` module

## Migration

For version prior `0.2.1` we had

```
module "role" {
  source     = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=master"
....
  principals_arns = ["arn:aws:iam::123456789012:role/workers"]
  principals_services_arns = [ "elasticmapreduce.amazonaws.com" ]
}
```

now should be

```
module "role" {
  source     = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=master"
....
   principals = {
      AWS = ["arn:aws:iam::123456789012:role/workers"]
      Services = [ "elasticmapreduce.amazonaws.com" ]
   }
}
```