### PR TITLE
Do not rely on length of list

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The [`example`](./example) directory contains complete working examples with var
 | name | Name (e.g. `app` or `chamber`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | policy_description | The description of the IAM policy that is visible in the IAM policy manager | string | - | yes |
+| policy_document_count | Number of policy documents (length of policy_documents list). | string | `1` | no |
 | policy_documents | List of JSON IAM policy documents | list | `<list>` | no |
 | principals | Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | map | `<map>` | no |
 | role_description | The description of the IAM role that is visible in the IAM role manager | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,6 +9,7 @@
 | name | Name (e.g. `app` or `chamber`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | policy_description | The description of the IAM policy that is visible in the IAM policy manager | string | - | yes |
+| policy_document_count | Number of policy documents (length of policy_documents list). | string | `1` | no |
 | policy_documents | List of JSON IAM policy documents | list | `<list>` | no |
 | principals | Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | map | `<map>` | no |
 | role_description | The description of the IAM role that is visible in the IAM role manager | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "assume_role" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "${element(keys(var.principals), count.index)}"
+      type        = "${element(keys(var.principals), count.index)}"
       identifiers = ["${var.principals[element(keys(var.principals), count.index)]}"]
     }
   }
@@ -42,14 +42,14 @@ module "aggregated_policy" {
 }
 
 resource "aws_iam_policy" "default" {
-  count       = "${var.enabled == "true" && length(var.policy_documents) > 0 ? 1 : 0}"
+  count       = "${var.enabled == "true" && var.policy_document_count > 0 ? 1 : 0}"
   name        = "${module.label.id}"
   description = "${var.policy_description}"
   policy      = "${module.aggregated_policy.result_document}"
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  count      = "${var.enabled == "true" && length(var.policy_documents) > 0 ? 1 : 0}"
+  count      = "${var.enabled == "true" && var.policy_document_count > 0 ? 1 : 0}"
   role       = "${aws_iam_role.default.name}"
   policy_arn = "${aws_iam_policy.default.arn}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,9 +50,8 @@ variable "policy_documents" {
 }
 
 variable "policy_document_count" {
-  type        = "string"
   description = "Number of policy documents (length of policy_documents list)."
-  default     = "1"
+  default     = 1
 }
 
 variable "max_session_duration" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "policy_documents" {
   default     = []
 }
 
+variable "policy_document_count" {
+  type        = "string"
+  description = "Number of policy documents (length of policy_documents list)."
+  default     = "1"
+}
+
 variable "max_session_duration" {
   default     = 3600
   description = "The maximum session duration (in seconds) for the role. Can have a value from 1 hour to 12 hours"


### PR DESCRIPTION
## what
Explicitly pass in length of `policy_documents` list
## why
Terraform does not pass lengths of lists between modules, causing `value of 'count' cannot be computed` errors if you rely on `length(var.policy_documents)`