### PR TITLE
Rename `kms_master_key_id` to `kms_master_key_arn`

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,5 +1,5 @@
 module "kms_key" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=master"
+  source    = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=0.11/master"
   namespace = "cp"
   stage     = "prod"
   name      = "app"
@@ -15,7 +15,7 @@ module "kms_key" {
 }
 
 module "bucket" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-s3-bucket.git?ref=master"
+  source  = "git::https://github.com/cloudposse/terraform-aws-s3-bucket.git?ref=0.11/master"
   enabled = "true"
 
   namespace = "cp"
@@ -29,8 +29,8 @@ module "bucket" {
   versioning_enabled = "false"
   user_enabled       = "false"
 
-  sse_algorithm     = "aws:kms"
-  kms_master_key_id = "${module.kms_key.key_id}"
+  sse_algorithm      = "aws:kms"
+  kms_master_key_arn = "${module.kms_key.key_arn}"
 }
 
 data "aws_iam_policy_document" "resource_full_access" {


### PR DESCRIPTION
## What
* Rename `kms_master_key_id` to `kms_master_key_arn`

## Why
* To solve confusing of variable, because really it expects arn https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#enable-default-server-side-encryption 