### PR TITLE
Drop unused null provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ For automated tests of the complete example using [bats](https://github.com/bats
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* Drop `hashicorp/null` provider from dependencies

## why
* As far as I can tell the null provider is not used and I do not think it is needed for any kind of indirect dependency
* I think it was needed at some point for terraform-null-label 

## references
* Closes #31 
