### PR TITLE
Fix: Fix Variable Description Typo for `var.use_fullname`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ For automated tests of the complete example using [bats](https://github.com/bats
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]` will be used.<br><br>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
+| <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]`) will be used.<br><br>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -64,7 +64,7 @@
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]` will be used.<br><br>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
+| <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]`) will be used.<br><br>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "use_fullname" {
   type        = bool
   default     = true
   description = <<-EOT
-  If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]` will be used.
+  If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]`) will be used.
 
   Otherwise, `var.name` will be used for the IAM role name.
   EOT


### PR DESCRIPTION
## what
* Fix variable description typo introduced in #35 for `var.use_fullname`

## why
* Minor typo (unmatched right bracket).

## references
* #35 

