### PR TITLE
Disabling all tags in all iam resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "default" {
   max_session_duration = var.max_session_duration
   permissions_boundary = var.permissions_boundary
   path                 = var.path
-  tags                 = var.role_tags_enabled ? module.this.tags : null
+  tags                 = var.tags_enabled ? module.this.tags : null
 }
 
 data "aws_iam_policy_document" "default" {
@@ -48,7 +48,7 @@ resource "aws_iam_policy" "default" {
   description = var.policy_description
   policy      = join("", data.aws_iam_policy_document.default.*.json)
   path        = var.path
-  tags        = module.this.tags
+  tags        = var.tags_enabled ? module.this.tags : null
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -83,8 +83,8 @@ variable "path" {
   default     = "/"
 }
 
-variable "role_tags_enabled" {
+variable "tags_enabled" {
   type        = string
-  description = "Enable/disable tags on IAM roles"
+  description = "Enable/disable tags on IAM roles and policies"
   default     = true
 }


### PR DESCRIPTION
## what
* In https://github.com/cloudposse/terraform-aws-iam-role/pull/43 I added the option to disable role tags but in environments where roles are created under very strict controls, the policy tags for the roles sometimes can't be tagged. This change disable tags for all IAM related resources.
* 
## why
* to disable tags for role-related things. Use one variable instead of two.

## references
* https://github.com/cloudposse/terraform-aws-iam-role/pull/43
