### PR TITLE
Bugfix/remove tags enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_role" "default" {
   max_session_duration = var.max_session_duration
   permissions_boundary = var.permissions_boundary
   path                 = var.path
-  tags                 = var.tags_enabled ? module.this.tags : null
+  tags                 = module.this.tags
 }
 
 resource "aws_iam_role_policy" "default" {
@@ -64,7 +64,7 @@ resource "aws_iam_policy" "default" {
   description = var.policy_description
   policy      = join("", data.aws_iam_policy_document.default[*].json)
   path        = var.path
-  tags        = var.tags_enabled ? module.this.tags : null
+  tags        = module.this.tags
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,12 +89,6 @@ variable "path" {
   default     = "/"
 }
 
-variable "tags_enabled" {
-  type        = bool
-  description = "Enable/disable tags on IAM roles and policies"
-  default     = true
-}
-
 variable "inline_policy_enabled" {
   type        = bool
   description = "Whether or not to enable an inline policy instead of a reusable managed policy"


### PR DESCRIPTION
what

- Removed the tags_enabled variable and set the tags as {}.


why

- Since tags from contex.tf is used to set the tags as {}, the variable tags_enabled is no longer needed.


references

- Closes #81

