### PR TITLE
fix: accept map or list for policy arns

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,27 +141,27 @@ For automated tests of the complete example using [bats](https://github.com/bats
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_role_name"></a> [role\_name](#module\_role\_name) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -175,7 +175,7 @@ For automated tests of the complete example using [bats](https://github.com/bats
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_assume_role_actions"></a> [assume\_role\_actions](#input\_assume\_role\_actions) | The IAM action to be granted by the AssumeRole policy | `list(string)` | <pre>[<br/>  "sts:AssumeRole",<br/>  "sts:TagSession"<br/>]</pre> | no |
 | <a name="input_assume_role_conditions"></a> [assume\_role\_conditions](#input\_assume\_role\_conditions) | List of conditions for the assume role policy | <pre>list(object({<br/>    test     = string<br/>    variable = string<br/>    values   = list(string)<br/>  }))</pre> | `[]` | no |
@@ -193,7 +193,8 @@ For automated tests of the complete example using [bats](https://github.com/bats
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | List of managed policies to attach to created role | `set(string)` | `[]` | no |
+| <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | A list of IAM Policy ARNs to attach to the created role.<br/>Changes to the list will have ripple effects, so use `managed_policy_arns_map` if possible. | `set(string)` | `[]` | no |
+| <a name="input_managed_policy_arns_map"></a> [managed\_policy\_arns\_map](#input\_managed\_policy\_arns\_map) | A map of name to IAM Policy ARNs to attach to the created role.<br/>The names are arbitrary, but must be known at plan time. The purpose of the name<br/>is so that changes to one ARN do not cause a ripple effect on the other ARNs.<br/>If you cannot provide unique names known at plan time, use `managed_policy_arns` instead. | `map(string)` | `{}` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | The maximum session duration (in seconds) for the role. Can have a value from 1 hour to 12 hours | `number` | `3600` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
@@ -214,7 +215,7 @@ For automated tests of the complete example using [bats](https://github.com/bats
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | The Amazon Resource Name (ARN) specifying the role |
 | <a name="output_id"></a> [id](#output\_id) | The stable and unique string identifying the role |
 | <a name="output_instance_profile"></a> [instance\_profile](#output\_instance\_profile) | Name of the ec2 profile (if enabled) |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "base" {
 }
 
 resource "aws_iam_policy" "base_as_managed" {
-  count = local.enabled ? 1 : 0
+  count  = local.enabled ? 1 : 0
   name   = module.this.id
   policy = one(data.aws_iam_policy_document.base[*].json)
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,6 +71,12 @@ data "aws_iam_policy_document" "base" {
   }
 }
 
+resource "aws_iam_policy" "base_as_managed" {
+  count = local.enabled ? 1 : 0
+  name   = module.this.id
+  policy = one(data.aws_iam_policy_document.base[*].json)
+}
+
 module "role" {
   source = "../.."
 
@@ -78,9 +84,13 @@ module "role" {
   use_fullname = var.use_fullname
 
   policy_documents = [
-    join("", data.aws_iam_policy_document.resource_full_access.*.json),
-    join("", data.aws_iam_policy_document.base.*.json),
+    one(data.aws_iam_policy_document.resource_full_access[*].json),
+    one(data.aws_iam_policy_document.base[*].json),
   ]
+
+  managed_policy_arns_map = {
+    "base" = one(aws_iam_policy.base_as_managed[*].arn)
+  }
 
   policy_document_count = 2
   policy_description    = "Test IAM policy"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  managed_policy_arns_map = merge({ for i, a in var.managed_policy_arns : format("_#%v_", i) => a }, var.managed_policy_arns_map)
+}
+
 data "aws_iam_policy_document" "assume_role" {
   # if the module is enabled and we don't use a `assume_role_policy` then enable the aws_iam_policy_document datasource
   count = module.this.enabled && var.assume_role_policy == null ? length(keys(var.principals)) : 0
@@ -37,7 +41,7 @@ module "role_name" {
 resource "aws_iam_role" "default" {
   count                = module.this.enabled ? 1 : 0
   name                 = var.use_fullname ? module.role_name.id : module.this.name
-  assume_role_policy   = join("", data.aws_iam_policy_document.assume_role_aggregated[*].json)
+  assume_role_policy   = one(data.aws_iam_policy_document.assume_role_aggregated[*].json)
   description          = var.role_description
   max_session_duration = var.max_session_duration
   permissions_boundary = var.permissions_boundary
@@ -49,9 +53,9 @@ resource "aws_iam_role_policy" "default" {
   count = module.this.enabled && var.policy_document_count > 0 && var.inline_policy_enabled ? 1 : 0
 
   name = var.policy_name != "" && var.policy_name != null ? var.policy_name : module.this.id
-  role = join("", aws_iam_role.default[*].name)
+  role = one(aws_iam_role.default[*].name)
 
-  policy = join("", data.aws_iam_policy_document.default[*].json)
+  policy = one(data.aws_iam_policy_document.default[*].json)
 }
 
 data "aws_iam_policy_document" "default" {
@@ -63,26 +67,26 @@ resource "aws_iam_policy" "default" {
   count       = module.this.enabled && var.policy_document_count > 0 && !var.inline_policy_enabled ? 1 : 0
   name        = var.policy_name != "" && var.policy_name != null ? var.policy_name : module.this.id
   description = var.policy_description
-  policy      = join("", data.aws_iam_policy_document.default[*].json)
+  policy      = one(data.aws_iam_policy_document.default[*].json)
   path        = var.path
   tags        = module.this.tags
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
   count      = module.this.enabled && var.policy_document_count > 0 && !var.inline_policy_enabled ? 1 : 0
-  role       = join("", aws_iam_role.default[*].name)
-  policy_arn = join("", aws_iam_policy.default[*].arn)
+  role       = one(aws_iam_role.default[*].name)
+  policy_arn = one(aws_iam_policy.default[*].arn)
 }
 
 resource "aws_iam_role_policy_attachment" "managed" {
-  for_each   = module.this.enabled ? var.managed_policy_arns : []
-  role       = join("", aws_iam_role.default[*].name)
+  for_each   = module.this.enabled ? local.managed_policy_arns_map : {}
+  role       = one(aws_iam_role.default[*].name)
   policy_arn = each.key
 }
 
 resource "aws_iam_instance_profile" "default" {
   count = module.this.enabled && var.instance_profile_enabled ? 1 : 0
   name  = module.this.id
-  role  = join("", aws_iam_role.default[*].name)
+  role  = one(aws_iam_role.default[*].name)
   tags  = module.this.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy_attachment" "default" {
 resource "aws_iam_role_policy_attachment" "managed" {
   for_each   = module.this.enabled ? local.managed_policy_arns_map : {}
   role       = one(aws_iam_role.default[*].name)
-  policy_arn = each.key
+  policy_arn = each.value
 }
 
 resource "aws_iam_instance_profile" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
 output "name" {
-  value       = join("", aws_iam_role.default.*.name)
+  value       = one(aws_iam_role.default[*].name)
   description = "The name of the IAM role created"
 }
 
 output "id" {
-  value       = join("", aws_iam_role.default.*.unique_id)
+  value       = one(aws_iam_role.default[*].unique_id)
   description = "The stable and unique string identifying the role"
 }
 
 output "arn" {
-  value       = join("", aws_iam_role.default.*.arn)
+  value       = one(aws_iam_role.default[*].arn)
   description = "The Amazon Resource Name (ARN) specifying the role"
 }
 
 output "policy" {
-  value       = join("", data.aws_iam_policy_document.default.*.json)
+  value       = one(data.aws_iam_policy_document.default[*].json)
   description = "Role policy document in json format. Outputs always, independent of `enabled` variable"
 }
 
 output "instance_profile" {
+  value       = one(aws_iam_instance_profile.default[*].name)
   description = "Name of the ec2 profile (if enabled)"
-  value       = join("", aws_iam_instance_profile.default.*.name)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,8 +28,22 @@ variable "policy_document_count" {
 
 variable "managed_policy_arns" {
   type        = set(string)
-  description = "List of managed policies to attach to created role"
+  description = <<-EOT
+    A list of IAM Policy ARNs to attach to the created role.
+    Changes to the list will have ripple effects, so use `managed_policy_arns_map` if possible.
+    EOT
   default     = []
+}
+
+variable "managed_policy_arns_map" {
+  type        = map(string)
+  description = <<-EOT
+    A map of name to IAM Policy ARNs to attach to the created role.
+    The names are arbitrary, but must be known at plan time. The purpose of the name
+    is so that changes to one ARN do not cause a ripple effect on the other ARNs.
+    If you cannot provide unique names known at plan time, use `managed_policy_arns` instead.
+    EOT
+  default     = {}
 }
 
 variable "max_session_duration" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- This PR introduces the ability to specify policy arns as a map instead of list.
- refactor: converts the `join()` statements to the more modern `one()`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Currently the plan fails because the keys of the `for_each` argument are not known if the reference is dynamic in the list.
Now, users can provide arbitrary keys that are known at plan time.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

Basically copy-pasted from https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/pull/198 which has the same reason to introduce this new behavior.

Closes #91
